### PR TITLE
Fix compatibility with Docker user namespace remapping

### DIFF
--- a/docker-pussh
+++ b/docker-pussh
@@ -155,6 +155,8 @@ run_unregistry() {
             --name $UNREGISTRY_CONTAINER \
             -p 127.0.0.1:$UNREGISTRY_PORT:5000 \
             -v /run/containerd/containerd.sock:/run/containerd/containerd.sock \
+            --userns=host \
+            --user root:root \
             $UNREGISTRY_IMAGE" 2>&1);
         then
             return 0


### PR DESCRIPTION
Fixes an issue where `docker pussh` fails on systems with Docker user namespace remapping enabled (`"userns-remap": "default"`), due to permission errors accessing the containerd socket.

## Root Cause

With `userns-remap` enabled, containers run in an isolated user namespace. This remapping causes permission issues when trying to access host resources like `/run/containerd/containerd.sock`.

## Fix

The `unregistry` container now runs with:

* `--userns=host` to disable user namespace remapping
* `--user root:root` to ensure it runs as the real root user

These options are required for proper access to host-level resources.

## Changes

* Updated `run_unregistry()` to include `--userns=host` and `--user root:root`
