### PR TITLE
feat: Add version bumping script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,21 +34,22 @@ You just want to move an image from A to B. Why is this so hard?
 docker pussh myapp:latest user@server
 ```
 
-That's it. Your image is on the remote server. No registry setup, no subscription, no intermediate storage, no 
+That's it. Your image is on the remote server. No registry setup, no subscription, no intermediate storage, no
 exposed ports. Just a **direct transfer** of the **missing layers** over SSH.
 
 Here's what happens under the hood:
+
 1. Establishes SSH tunnel to the remote server
 2. Starts a temporary unregistry container
 3. Forwards a random localhost port to the unregistry port over the tunnel
-4. `docker push` to unregistry through the forwarded port, transferring only the layers that don't already exist 
+4. `docker push` to unregistry through the forwarded port, transferring only the layers that don't already exist
    remotely. The transferred image is instantly available on the remote Docker daemon
 5. Stops the unregistry container and closes the SSH tunnel
 
 It's like `rsync` for Docker images — simple and efficient.
 
-> [!NOTE]  
-> Unregistry was created for [Uncloud](https://github.com/psviderski/uncloud), a lightweight tool for deploying 
+> [!NOTE]
+> Unregistry was created for [Uncloud](https://github.com/psviderski/uncloud), a lightweight tool for deploying
 > containers across multiple Docker hosts. We needed something simpler than a full registry but more efficient than
 > save/load.
 
@@ -69,18 +70,28 @@ ln -sf $(brew --prefix)/bin/docker-pussh ~/.docker/cli-plugins/docker-pussh
 
 ### macOS/Linux via direct download
 
+Download the current version:
+
 ```bash
-# Download the latest version
-curl -sSL https://raw.githubusercontent.com/psviderski/unregistry/main/docker-pussh \
+# Download the script to the docker plugins directory
+curl -sSL https://raw.githubusercontent.com/psviderski/unregistry/v0.1.0/docker-pussh \
   -o ~/.docker/cli-plugins/docker-pussh
 
 # Make it executable
 chmod +x ~/.docker/cli-plugins/docker-pussh
 ```
 
+If you want to download and use the latest version from the main branch:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/psviderski/unregistry/main/docker-pussh \
+  -o ~/.docker/cli-plugins/docker-pussh
+chmod +x ~/.docker/cli-plugins/docker-pussh
+```
+
 ### Windows
 
-Windows is not currently supported, but you can try using [WSL 2](https://docs.docker.com/desktop/features/wsl/) 
+Windows is not currently supported, but you can try using [WSL 2](https://docs.docker.com/desktop/features/wsl/)
 with the above Linux instructions.
 
 ### Verify installation
@@ -91,8 +102,8 @@ docker pussh --help
 
 ## Usage
 
-Push an image to a remote server. Please make sure the SSH user has permissions to run `docker` commands (user is 
-`root` or non-root user is in `docker` group). If `sudo` is required, ensure the user can run `sudo docker` without 
+Push an image to a remote server. Please make sure the SSH user has permissions to run `docker` commands (user is
+`root` or non-root user is in `docker` group). If `sudo` is required, ensure the user can run `sudo docker` without
 a password prompt.
 
 ```bash
@@ -152,10 +163,12 @@ docker pussh image:latest user@192.168.1.100
 ## Requirements
 
 ### On local machine
+
 - Docker CLI with plugin support (Docker 19.03+)
 - OpenSSH client
 
 ### On remote server
+
 - Docker is installed and running
 - SSH user has permissions to run `docker` commands (user is `root` or non-root user is in `docker` group)
 - If `sudo` is required, ensure the user can run `sudo docker` without a password prompt
@@ -165,6 +178,7 @@ docker pussh image:latest user@192.168.1.100
 > enabled. This allows unregistry to access images more efficiently.
 >
 > Add the following configuration to `/etc/docker/daemon.json` on the remote server and restart the `docker` service:
+>
 > ```json
 > {
 >   "features": {
@@ -216,12 +230,13 @@ Found a bug or have a feature idea? We'd love your help!
 
 ## Inspiration & acknowledgements
 
-- [Spegel](https://github.com/spegel-org/spegel) - P2P container image registry that inspired me to implement a 
+- [Spegel](https://github.com/spegel-org/spegel) - P2P container image registry that inspired me to implement a
   registry that uses containerd image store as a backend.
 - [Docker Distribution](https://github.com/distribution/distribution) - the bulletproof Docker registry implementation
   that unregistry uses as a base.
 
 ##
+
 <div align="center">
   Built with ❤️ by <a href="https://github.com/psviderski">Pasha Sviderski</a> who just wanted to deploy his images
 </div>

--- a/docker-pussh
+++ b/docker-pussh
@@ -5,13 +5,15 @@ if [[ "${UNREGISTRY_DEBUG:-}" == "1" ]]; then
     set -x
 fi
 
+VERSION="0.1.0"
+
 # Return metadata expected by the Docker CLI plugin framework: https://github.com/docker/cli/pull/1564
 if [ "${1:-}" = "docker-cli-plugin-metadata" ]; then
     cat <<EOF
 {
   "SchemaVersion": "0.1.0",
   "Vendor": "https://github.com/psviderski",
-  "Version": "0.1.0",
+  "Version": "${VERSION}",
   "ShortDescription": "Upload image to remote Docker daemon via SSH without external registry"
 }
 EOF
@@ -276,6 +278,10 @@ while [ $# -gt 0 ]; do
             ;;
         -h|--help)
             usage
+            exit 0
+            ;;
+        -v|--version)
+            echo "docker-pussh, version ${VERSION}"
             exit 0
             ;;
         -*)

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure a new version argument is provided
+if [ "$#" -lt 1 ]; then
+    echo "Usage: ${0} <new-version> [--execute]"
+    exit 1
+fi
+NEW_VERSION="$1"
+EXECUTE=0
+
+# Exit if there are uncommitted changes
+if ! git diff-index --quiet HEAD --; then
+    echo "Error: There are uncommitted changes. Please commit or stash them before running this script."
+    exit 1
+fi
+
+# Check if the --execute flag is passed
+if [ "${2:-}" == "--execute" ]; then
+    EXECUTE=1
+else
+    echo "Dry-run mode: No changes will be committed or tagged. Use '--execute' to apply changes."
+fi
+
+# Validate semantic version format
+if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: Version must be in semantic format (e.g., 1.2.3)"
+    exit 1
+fi
+
+echo "Preparing to bump version to ${NEW_VERSION}..."
+echo "Updating version in relevant files..."
+
+# Update version in README.md using backreference
+sed -i "s|\(https://raw.githubusercontent.com/psviderski/unregistry/v\)[0-9]\+\.[0-9]\+\.[0-9]\+\(/docker-pussh\)|\1${NEW_VERSION}\2|g" README.md
+
+# Update VERSION field in docker-pussh
+sed -i "s/^VERSION=\"[0-9]\+\.[0-9]\+\.[0-9]\+\"/VERSION=\"${NEW_VERSION}\"/" docker-pussh
+
+echo -e "Changes pending:\n---"
+git diff
+echo "---"
+
+TAG_NAME="v$NEW_VERSION"
+COMMIT_MESSAGE="release: Bump version to ${NEW_VERSION}"
+
+if [ "$EXECUTE" = "1" ]; then
+    echo "Executing changes..."
+    git add -u
+    git commit -m "${COMMIT_MESSAGE}"
+    git tag "${TAG_NAME}"
+    echo "Version bumped to ${NEW_VERSION} and git tag ${TAG_NAME} created."
+else
+    echo "Would create commit with message: '${COMMIT_MESSAGE}'"
+    echo "Would create tag: ${TAG_NAME}"
+    echo "Reverting back changes..."
+    git checkout .
+fi


### PR DESCRIPTION
Adds the version bumping script and updates the README with non-latest installation instructions.

Will figure out the goreleaser bits in a follow-up, this should already help a bit.