### PR TITLE
feat: --image-transfer-mode option for air-gapped environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,26 @@ Push a specific platform for a multi-platform image. The local Docker has to use
 docker pussh myapp:latest user@server --platform linux/amd64
 ```
 
+Transfer the unregistry image using SCP mode (useful for air-gapped environments where the remote server
+cannot access the internet to pull the unregistry image):
+
+```shell
+docker pussh myapp:latest user@server --image-transfer-mode scp
+```
+
+For different architectures, specify the platform to ensure the correct unregistry image variant is transferred:
+
+```shell
+# Transfer unregistry image for specific platform (e.g., ARM64 server)
+docker pussh --image-transfer-mode scp --platform linux/arm64 myapp:latest user@server
+```
+
+**Platform-specific transfers**: When using `--image-transfer-mode scp` with `--platform`, the plugin will:
+
+- Pull the correct platform variant of the unregistry image locally
+- Transfer only that platform variant to the remote host
+- Skip pulling if the image is already available locally
+
 ## Use cases
 
 ### Deploy to production servers
@@ -233,7 +253,18 @@ Skip the registry complexity in your pipelines. Build and push directly to deplo
 
 ### Homelab and air-gapped environments
 
-Distribute images in isolated networks that can't access public registries over the internet.
+Distribute images in isolated networks that can't access public registries over the internet. Use the `--image-transfer-mode scp` option to transfer the unregistry image locally and then via SSH:
+
+```shell
+docker pussh myapp:latest user@server --image-transfer-mode scp
+```
+
+For different architectures, specify the platform to ensure the correct unregistry image variant is transferred:
+
+```shell
+# For ARM64 servers
+docker pussh --image-transfer-mode scp --platform linux/arm64 myapp:latest user@server
+```
 
 ## Advanced usage
 

--- a/docker-pussh
+++ b/docker-pussh
@@ -56,11 +56,24 @@ usage() {
     echo "  -i, --ssh-key path      Path to SSH private key for remote login (if not already added to SSH agent)."
     echo "      --platform string   Push a specific platform for a multi-platform image (e.g., linux/amd64, linux/arm64)."
     echo "                          Local Docker has to use containerd image store to support multi-platform images."
+    echo "                          For cross-platform builds (e.g., macOS to Linux), build with --platform first:"
+    echo "                          docker build --platform linux/amd64 -t myimage:latest ."
+    echo "                          When used with --image-transfer-mode scp, also determines the unregistry image platform."
+    echo "      --image-transfer-mode string   How to transfer the unregistry image to remote host (remote|scp, default: remote)."
+    echo "                          'remote': Pull unregistry image directly on remote host (requires internet access)."
+    echo "                          'scp': Pull unregistry image locally and transfer via SSH (for air-gapped environments)."
+    echo "                          With --platform, pulls and transfers only the target platform variant."
     echo ""
     echo "Examples:"
     echo "  docker pussh myimage:latest user@host"
     echo "  docker pussh --platform linux/amd64 myimage:latest host"
     echo "  docker pussh myimage:latest user@host:2222 -i ~/.ssh/id_ed25519"
+    echo "  docker pussh --image-transfer-mode scp myimage:latest user@host"
+    echo "  # Cross-platform: build for target platform first"
+    echo "  docker build --platform linux/amd64 -t myimage:latest ."
+    echo "  docker pussh --platform linux/amd64 myimage:latest user@host"
+    echo "  # Air-gapped with platform-specific unregistry image"
+    echo "  docker pussh --image-transfer-mode scp --platform linux/amd64 myimage:latest user@host"
 }
 
 # SSH command arguments to be used for all ssh commands after establishing a shared "master" connection
@@ -142,15 +155,59 @@ UNREGISTRY_CONTAINER=""
 # Unregistry port on the remote host that is bound to localhost. It's populated by run_unregistry function.
 UNREGISTRY_PORT=""
 
+# Transfer unregistry image to remote host using SCP mode (docker save | ssh docker load)
+transfer_unregistry_image_scp() {
+    info "Checking unregistry image availability locally..."
+    
+    # Check if the image exists for the target platform
+    if [ -n "$DOCKER_PLATFORM" ]; then
+        if docker image inspect "$UNREGISTRY_IMAGE" >/dev/null 2>&1 && \
+           docker manifest inspect "$UNREGISTRY_IMAGE" 2>/dev/null | grep -q "\"architecture\": \"$(echo "$DOCKER_PLATFORM" | cut -d'/' -f2)\""; then
+            info "Unregistry image for platform $DOCKER_PLATFORM already available locally"
+        else
+            info "Pulling unregistry image locally for platform $DOCKER_PLATFORM..."
+            if ! docker pull --platform "$DOCKER_PLATFORM" "$UNREGISTRY_IMAGE"; then
+                error "Failed to pull unregistry image locally for platform $DOCKER_PLATFORM: $UNREGISTRY_IMAGE"
+            fi
+        fi
+    else
+        if docker image inspect "$UNREGISTRY_IMAGE" >/dev/null 2>&1; then
+            info "Unregistry image already available locally"
+        else
+            info "Pulling unregistry image locally..."
+            if ! docker pull "$UNREGISTRY_IMAGE"; then
+                error "Failed to pull unregistry image locally: $UNREGISTRY_IMAGE"
+            fi
+        fi
+    fi
+
+    info "Transferring unregistry image to remote host via SSH..."
+    if [ -n "$DOCKER_PLATFORM" ]; then
+        if ! docker save --platform "$DOCKER_PLATFORM" "$UNREGISTRY_IMAGE" | ssh "${SSH_ARGS[@]}" "$REMOTE_SUDO docker load"; then
+            error "Failed to transfer unregistry image to remote host via SSH"
+        fi
+    else
+        if ! docker save "$UNREGISTRY_IMAGE" | ssh "${SSH_ARGS[@]}" "$REMOTE_SUDO docker load"; then
+            error "Failed to transfer unregistry image to remote host via SSH"
+        fi
+    fi
+    success "Unregistry image transferred to remote host"
+}
+
 # Run unregistry container on remote host with retry logic for port binding conflicts.
 # Sets UNREGISTRY_PORT and UNREGISTRY_CONTAINER global variables.
 run_unregistry() {
     local output
 
-    # Pull unregistry image if it doesn't exist on the remote host. This is done separately to not capture the output
-    # and print the pull progress to the terminal.
-    if ! ssh "${SSH_ARGS[@]}" "$REMOTE_SUDO docker image inspect $UNREGISTRY_IMAGE" >/dev/null 2>&1; then
-        ssh "${SSH_ARGS[@]}" "$REMOTE_SUDO docker pull $UNREGISTRY_IMAGE"
+    # Ensure unregistry image is available on remote host based on transfer mode
+    if [ "$IMAGE_TRANSFER_MODE" = "scp" ]; then
+        transfer_unregistry_image_scp
+    else
+        # Pull unregistry image if it doesn't exist on the remote host. This is done separately to not capture the output
+        # and print the pull progress to the terminal.
+        if ! ssh "${SSH_ARGS[@]}" "$REMOTE_SUDO docker image inspect $UNREGISTRY_IMAGE" >/dev/null 2>&1; then
+            ssh "${SSH_ARGS[@]}" "$REMOTE_SUDO docker pull $UNREGISTRY_IMAGE"
+        fi
     fi
 
     for _ in {1..10}; do
@@ -254,6 +311,7 @@ DOCKER_PLATFORM=""
 SSH_KEY=""
 IMAGE=""
 SSH_ADDRESS=""
+IMAGE_TRANSFER_MODE="remote"
 
 # Skip 'pussh' if called as Docker CLI plugin.
 if [ "${1:-}" = "pussh" ]; then
@@ -276,6 +334,16 @@ while [ $# -gt 0 ]; do
                 error "--platform option requires an argument.\n$help_command"
             fi
             DOCKER_PLATFORM="$2"
+            shift 2
+            ;;
+        --image-transfer-mode)
+            if [ -z "${2:-}" ]; then
+                error "--image-transfer-mode option requires an argument.\n$help_command"
+            fi
+            if [ "$2" != "remote" ] && [ "$2" != "scp" ]; then
+                error "--image-transfer-mode must be either 'remote' or 'scp'.\n$help_command"
+            fi
+            IMAGE_TRANSFER_MODE="$2"
             shift 2
             ;;
         -h|--help)

--- a/test-docker-pussh.sh
+++ b/test-docker-pussh.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -eu
+
+# Test script for docker-pussh --image-transfer-mode functionality
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCKER_PUSSH="$SCRIPT_DIR/docker-pussh"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # no color
+
+test_passed() {
+    echo -e "${GREEN}✓${NC} $1"
+}
+
+test_failed() {
+    echo -e "${RED}✗${NC} $1"
+    exit 1
+}
+
+echo "Testing docker-pussh --image-transfer-mode functionality..."
+
+# Test 1: Help should show the new option
+if "$DOCKER_PUSSH" --help | grep -q "image-transfer-mode"; then
+    test_passed "Help output includes image-transfer-mode option"
+else
+    test_failed "Help output missing image-transfer-mode option"
+fi
+
+# Test 2: Invalid mode should fail
+if "$DOCKER_PUSSH" --image-transfer-mode invalid myimage:latest user@host 2>&1 | grep -q "must be either 'remote' or 'scp'"; then
+    test_passed "Invalid image-transfer-mode correctly rejected"
+else
+    test_failed "Invalid image-transfer-mode not rejected"
+fi
+
+# Test 3: Valid modes should be accepted (we expect SSH connection to fail, but argument parsing should succeed)
+if "$DOCKER_PUSSH" --image-transfer-mode remote myimage:latest user@host 2>&1 | grep -q "Connecting to user@host"; then
+    test_passed "Remote mode argument parsing works"
+else
+    test_failed "Remote mode argument parsing failed"
+fi
+
+if "$DOCKER_PUSSH" --image-transfer-mode scp myimage:latest user@host 2>&1 | grep -q "Connecting to user@host"; then
+    test_passed "SCP mode argument parsing works"
+else
+    test_failed "SCP mode argument parsing failed"
+fi
+
+# Test 4: Default mode should work (no --image-transfer-mode specified)
+if "$DOCKER_PUSSH" myimage:latest user@host 2>&1 | grep -q "Connecting to user@host"; then
+    test_passed "Default mode (remote) works"
+else
+    test_failed "Default mode (remote) failed"
+fi
+
+echo -e "${GREEN}All tests passed!${NC}" 


### PR DESCRIPTION
Add new --image-transfer-mode option with 'remote' (default) and 'scp' modes:
- 'remote': Pull unregistry image directly on remote host (existing behavior)
- 'scp': Pull unregistry image locally and transfer via SSH for air-gapped environments

When --image-transfer-mode scp is used with --platform:
- Check if unregistry image is already available locally for target platform
- Pull only the specific platform variant if needed using docker pull --platform
- Transfer only the target platform variant using docker save --platform
- Skip pulling if image already exists locally

closes #17 