### PR TITLE
readme: correct the Save/Load approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You've built a Docker image locally. Now you need it on your server. Your option
 
 - **Docker Hub / GitHub Container Registry** - Your code is now public, or you're paying for private repos
 - **Self-hosted registry** - Another service to maintain, secure, and pay for storage
-- **Save/Load** - `docker save | ssh | docker load` transfers the entire image, even if 90% already exists on the server
+- **Save/Load** - `docker save | ssh <remote server> docker load` transfers the entire image, even if 90% already exists on the server
 - **Rebuild remotely** - Wastes time and server resources. Plus now you're debugging why the build fails in production
 
 You just want to move an image from A to B. Why is this so hard?


### PR DESCRIPTION
In `docker save | ssh | docker load`, `docker load` will be run in local machine. The correct way to upload image is that `docker save | ssh <remote server> docker load`, which `docker load` will be run in remote server