### PR TITLE
docs: add docker-image-cleanup to third-party projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ docker pussh myapp:latest prod-server
 - https://github.com/SonOfBytes/unregistry-action - GitHub Action to push Docker images to remote servers using
   `docker-pussh` plugin for Docker CLI
 - https://github.com/RezaKargar/setup-unregistry - GitHub Action to install `docker-pussh` plugin for Docker CLI
+- https://github.com/iloveitaly/docker-image-cleanup - Python tool to manage Docker images in self-hosted registries by
+  automatically removing outdated images while preserving recent and actively used ones
 
 ## Contributing
 


### PR DESCRIPTION
Add docker-image-cleanup Python tool to the third-party projects list. This tool helps manage Docker images in self-hosted registries by automatically cleaning up outdated images while preserving recent and actively used ones.

Resolves #32