### PR TITLE
fix: retrying for big layers by waiting for the writer lock

### DIFF
--- a/docker-pussh
+++ b/docker-pussh
@@ -23,7 +23,7 @@ fi
 
 # Pin the unregistry image version. The image doesn't change too often compared to the script,
 # so we want to avoid unnecessary pulls of the latest image version.
-UNREGISTRY_VERSION=0.1.3
+UNREGISTRY_VERSION=0.4.1
 UNREGISTRY_IMAGE=${UNREGISTRY_IMAGE:-ghcr.io/psviderski/unregistry:${UNREGISTRY_VERSION}}
 
 # Docker command path on remote host.

--- a/internal/storage/containerd/blob.go
+++ b/internal/storage/containerd/blob.go
@@ -101,7 +101,7 @@ func (b *blobStore) Put(ctx context.Context, mediaType string, blob []byte) (dis
 	return desc, nil
 }
 
-// Create creates a blob writer to add a blob to the containerd content store.`
+// Create creates a blob writer to add a blob to the containerd content store.
 func (b *blobStore) Create(ctx context.Context, _ ...distribution.BlobCreateOption) (
 	distribution.BlobWriter, error,
 ) {

--- a/internal/storage/containerd/blobwriter.go
+++ b/internal/storage/containerd/blobwriter.go
@@ -58,7 +58,7 @@ func newBlobWriter(
 
 	// Open a containerd content writer with the lease.
 	ctx = leases.WithLease(ctx, lease.ID)
-	writer, err := client.ContentStore().Writer(ctx, content.WithRef("upload-"+id))
+	writer, err := content.OpenWriter(ctx, client.ContentStore(), content.WithRef("upload-"+id))
 	if err != nil {
 		_ = client.LeasesService().Delete(ctx, lease)
 		return nil, fmt.Errorf("create containerd content writer: %w", err)


### PR DESCRIPTION
Fixes: #45
Related PR: https://github.com/psviderski/unregistry/pull/54

Use `content.OpenWriter` to wait until the reference is unlocked when creating a containerd content store writer.

The following error in unregistry was only possible when unregistry tried to create a new blob writer with the blow writer ID that was previously created:
```
error resolving upload: create containerd content writer: ref moby/1/upload-35015e47-eac0-4b24-aaaf-ca4329f004bd locked for 17.511331877s (since 2025-10-06 01:54:27.634765743 +0000 UTC m=+4330.405727369): unavailable
```

And this is possible only when the distribution implementation calls the [`blobStore.Resume`](https://github.com/psviderski/unregistry/blob/83145b8448c1b2820ecdd02b3d1259513e94f7c6/internal/storage/containerd/blob.go#L111-L114).

I was able to reproduce the issue #45 only when using Docker with disabled containerd image store locally (the one that is used with `pussh`) and only when pushing to a remote RPi with a relatively slow microSD. Apparently, the new Docker implementation of `docker push` when using the containerd image store doesn't use the resume requests.

The following errors in `containerd` logs are still logged when `content.OpenWriter` attempts to create a writer and waits until the lock is freed:
```
(*service).Write failed" error="rpc error: code = Unavailable desc = ref moby/1/upload-46990068-fd5a-4598-95e7-ef8967e17d1a locked for 15.733253758s
```
which I believe is normal as I was able to find similar logs for the writers unrelated to unregistry on some of my machines. There is a comment in containerd to remove this noisy log line: https://github.com/containerd/containerd/blob/2f24aa00a58de442713ea60e4206041e00dcf012/plugins/services/content/contentserver/contentserver.go#L274-L275