### PR TITLE
fix: make the docker-pussh script compatible with a podman host

### DIFF
--- a/docker-pussh
+++ b/docker-pussh
@@ -511,6 +511,10 @@ DOCKER_PUSH_OPTS=()
 if [[ -n "${DOCKER_PLATFORM}" ]]; then
     DOCKER_PUSH_OPTS+=("--platform" "${DOCKER_PLATFORM}")
 fi
+# If docker on the host is podman emulating docker then force it to push using http
+if docker -v | grep -q --ignore-case "podman"; then
+    DOCKER_PUSH_OPTS+=("--tls-verify=false")
+fi
 
 # Try push with retry logic for connection issues
 PUSH_RETRY_COUNT=3


### PR DESCRIPTION
Small fix to the docker-pussh script to make it compatible with a podman host.

The blocking issue was that podman attempts to push to the registry using HTTPS only. By adding --tls-verify=false to the push command, we can bypass this restriction and successfully push to unregistry.