### PR TITLE
[FIX] Unpack images after push to avoid slow container startup

### DIFF
--- a/docker-pussh
+++ b/docker-pussh
@@ -545,32 +545,23 @@ if [[ "${PUSH_SUCCESS}" = false ]]; then
     error "Failed to push image after ${PUSH_RETRY_COUNT} attempts."
 fi
 
-REMOTE_RETAG_IMAGE=""
-if [[ "${REMOTE_IMAGE}" != "${IMAGE}" ]]; then
-    REMOTE_RETAG_IMAGE="${REMOTE_IMAGE}"
-fi
-
-# Pull image from unregistry if remote Docker doesn't use containerd image store.
+# Pull image from unregistry.
+# Note: docker pull also unpacks the image into the default snapshotter on the remote host.
+REMOTE_REGISTRY_IMAGE="localhost:${UNREGISTRY_PORT}/${REMOTE_IMAGE}"
+info "Pulling image on remote host..."
 # shellcheck disable=SC2029
-if ! ssh "${SSH_ARGS[@]}" "${REMOTE_SUDO} ${REMOTE_DOCKER_PATH} info -f '{{ .DriverStatus }}' | grep -q 'containerd.snapshotter'"; then
-    info "Remote Docker doesn't use containerd image store. Pulling image from unregistry..."
-    REMOTE_REGISTRY_IMAGE="localhost:${UNREGISTRY_PORT}/${REMOTE_IMAGE}"
-    if ! ssh "${SSH_ARGS[@]}" "${REMOTE_SUDO} ${REMOTE_DOCKER_PATH}  pull ${REMOTE_REGISTRY_IMAGE}"; then
-        error "Failed to pull image from unregistry on remote host."
-    fi
-    REMOTE_RETAG_IMAGE="${REMOTE_REGISTRY_IMAGE}"
+if ! ssh "${SSH_ARGS[@]}" "${REMOTE_SUDO} ${REMOTE_DOCKER_PATH} pull ${REMOTE_REGISTRY_IMAGE}"; then
+    error "Failed to pull image from unregistry on remote host."
 fi
 
 # Retag the image to the original name if needed and remove the temporary tag.
-if [[ -n "${REMOTE_RETAG_IMAGE}" ]]; then
-    # shellcheck disable=SC2029
-    if ! ssh "${SSH_ARGS[@]}" "${REMOTE_SUDO} ${REMOTE_DOCKER_PATH}  tag ${REMOTE_RETAG_IMAGE} ${IMAGE}"; then
-        error "Failed to retag image on remote host ${REMOTE_RETAG_IMAGE} → ${IMAGE}"
-    fi
-    # shellcheck disable=SC2029
-    ssh "${SSH_ARGS[@]}" "${REMOTE_SUDO} ${REMOTE_DOCKER_PATH}  rmi ${REMOTE_RETAG_IMAGE}" >/dev/null || true
-    success "Retagged image on remote host ${REMOTE_RETAG_IMAGE} → ${IMAGE}"
+# shellcheck disable=SC2029
+if ! ssh "${SSH_ARGS[@]}" "${REMOTE_SUDO} ${REMOTE_DOCKER_PATH}  tag ${REMOTE_REGISTRY_IMAGE} ${IMAGE}"; then
+	error "Failed to retag image on remote host ${REMOTE_REGISTRY_IMAGE} → ${IMAGE}"
 fi
+# shellcheck disable=SC2029
+ssh "${SSH_ARGS[@]}" "${REMOTE_SUDO} ${REMOTE_DOCKER_PATH}  rmi ${REMOTE_REGISTRY_IMAGE}" >/dev/null || true
+success "Retagged image on remote host ${REMOTE_REGISTRY_IMAGE} → ${IMAGE}"
 
 info "Removing unregistry container on remote host..."
 # shellcheck disable=SC2029

--- a/docker-pussh
+++ b/docker-pussh
@@ -554,7 +554,7 @@ if ! ssh "${SSH_ARGS[@]}" "${REMOTE_SUDO} ${REMOTE_DOCKER_PATH} pull ${REMOTE_RE
     error "Failed to pull image from unregistry on remote host."
 fi
 
-# Retag the image to the original name if needed and remove the temporary tag.
+# Retag the image to the original name and remove the temporary tag.
 # shellcheck disable=SC2029
 if ! ssh "${SSH_ARGS[@]}" "${REMOTE_SUDO} ${REMOTE_DOCKER_PATH}  tag ${REMOTE_REGISTRY_IMAGE} ${IMAGE}"; then
 	error "Failed to retag image on remote host ${REMOTE_REGISTRY_IMAGE} → ${IMAGE}"


### PR DESCRIPTION
I noticed that containers based on a large images transferred with `docker pussh` would hang for quite some time. This is because they get unpacked on first use not during the upload. I think it might make sense to do image unpacking as part of the transfer process, mirroring `docker pull` behavior.

This fix unpacks the image layers into the default snapshotter immediately after the image is created/updated in the containerd image store.