### PR TITLE
 [FIX] delete upload leases after tagging

### DIFF
--- a/internal/storage/containerd/blobwriter.go
+++ b/internal/storage/containerd/blobwriter.go
@@ -19,6 +19,7 @@ import (
 )
 
 const leaseExpiration = 1 * time.Hour
+const leaseLabel = "unregistry/upload.repo"
 
 // blobWriter is a resumable blob uploader to the containerd content store.
 // Implements distribution.BlobWriter.
@@ -27,11 +28,10 @@ type blobWriter struct {
 	repo   reference.Named
 	id     string
 
-	// lease is a containerd lease for writer that prevents garbage collection of the content. It's intentionally not
-	// deleted on successful blob commit to keep it while the registry is uploading other blobs and manifests and
-	// creating an image referencing them. Otherwise, the blob would be garbage collected immediately after lease is
-	// deleted if the blob is not referenced by an image.
-	// In the worst case, the lease and unreferenced blob will be garbage collected after leaseExpiration.
+	// lease is a containerd lease for writer that prevents garbage collection of the content while the registry
+	// is uploading other blobs and manifests. The lease is labeled with the repository name so that tagService.Tag
+	// can find and delete all upload leases after GC labels are set on the image content. If the image is never
+	// tagged, the lease expires after leaseExpiration.
 	lease  leases.Lease
 	writer content.Writer
 	// size is the total number of bytes written to writer.
@@ -46,10 +46,12 @@ func newBlobWriter(
 		id = uuid.NewString()
 	}
 
-	// Create a containerd lease to prevent garbage collection.
+	// Create a containerd lease to prevent garbage collection. The lease is labeled with the repository name
+	// so that tagService.Tag can find and delete all upload leases after GC labels are set.
 	opts := []leases.Opt{
 		leases.WithRandomID(),
 		leases.WithExpiration(leaseExpiration),
+		leases.WithLabels(map[string]string{leaseLabel: repo.Name()}),
 	}
 	lease, err := client.LeasesService().Create(ctx, opts...)
 	if err != nil {

--- a/internal/storage/containerd/repository.go
+++ b/internal/storage/containerd/repository.go
@@ -54,6 +54,7 @@ func (r *repository) Tags(_ context.Context) distribution.TagService {
 	canonicalRepo, _ := reference.ParseNormalizedNamed(r.name.String())
 	return &tagService{
 		client:        r.client,
+		repo:          r.name,
 		canonicalRepo: canonicalRepo,
 	}
 }

--- a/internal/storage/containerd/tags.go
+++ b/internal/storage/containerd/tags.go
@@ -16,6 +16,9 @@ import (
 // tagService implements distribution.TagService backed by the containerd image store.
 type tagService struct {
 	client *client.Client
+	// repo is the repository reference as provided by the distribution handler. Used to find upload leases
+	// labeled with the repository name.
+	repo reference.Named
 	// canonicalRepo is the repository reference in a normalized form, the way containerd image store expects it,
 	// for example, "docker.io/library/ubuntu"
 	canonicalRepo reference.Named
@@ -72,11 +75,6 @@ func (t *tagService) Tag(ctx context.Context, tag string, desc distribution.Desc
 	// deleted by GC once the leases that uploaded the content are expired or deleted.
 	// See for more details:
 	// https://github.com/containerd/containerd/blob/main/docs/garbage-collection.md#garbage-collection-labels
-	//
-	// TODO: delete unnecessary leases after setting the GC labels. It seems to be non-trivial to do so, because we need
-	//  to keep track of which leases were used to upload which content and share this info between
-	//  the blobStore/blobWriter and tagService. The downside of keeping them around is the image content will be kept
-	//  in the store even if the image is deleted, until the leases expire (default is leaseExpiration).
 
 	contentStore := t.client.ContentStore()
 	// Get all the children descriptors (manifests, config, layers) for an image index or manifest.
@@ -112,6 +110,22 @@ func (t *tagService) Tag(ctx context.Context, tag string, desc distribution.Desc
 		log.Debug("Updated existing image in containerd image store.")
 	} else {
 		log.Debug("Created new image in containerd image store.")
+	}
+
+	// Now that the image is created and GC labels protect its content, the upload leases are no longer needed.
+	// Delete them so that content can be properly garbage collected when the image is removed (e.g. via docker image rm).
+	leaseManager := t.client.LeasesService()
+	uploadLeases, err := leaseManager.List(ctx, fmt.Sprintf("labels.%q==%s", leaseLabel, t.repo.Name()))
+	if err != nil {
+		log.WithError(err).Warn("Failed to list upload leases.")
+	}
+	for _, l := range uploadLeases {
+		if err = leaseManager.Delete(ctx, l); err != nil {
+			log.WithError(err).WithField("lease", l.ID).Warn("Failed to delete upload lease.")
+		}
+	}
+	if len(uploadLeases) > 0 {
+		log.WithField("count", len(uploadLeases)).Debug("Deleted upload leases after setting GC labels.")
 	}
 
 	return nil


### PR DESCRIPTION
Currently if you run `docker image rm` on an image uploaded by unregistry it will untag it but not remove the content in containerd. This is because the image content is kept around until the leases expire (1 hr).

In this PR we add a lease label and then remove the leases tagged with the lease label after a sucessful upload in `tagService`. Now `docker image rm`, `docker image prune`, etc. immediately work as expected without needing to manually use `ctr` to remove the leases.

 ## Test Instructions

Note that its easiest to observe the difference on a clean remote that has no docker images on it yet (i.e. pruned with `sudo ctr -n moby leases rm $(sudo ctr -n moby leases ls -q)` and `docker image prune -a`).

### Reproduce Current Behavior

```bash
# On client
docker pussh ubuntu:24.04 user@remote

# On remote
docker system df # Make note of the storage space used by the images
docker image rm ubuntu:24.04 && docker system df # You'll see that the space used by the ubuntu image is still shown as in use because of the 1 hr lease.
sudo ctr -n moby leases rm $(sudo ctr -n moby leases ls -q) # Manually remove the leases.
docker image prune -a && docker system df # Now the space is reclaimed.
```

### Observe Behavior After Change

```bash
# On client
export UNREGISTRY_IMAGE=<custom image built from this PR and available on remote>
docker pussh ubuntu:24.04 user@remote

# On remote
docker system df # Make note of the storage space used by the images
docker image rm ubuntu:24.04 && docker system df # The space is reclaimed immediately without needing to use ctr to manually remove the leases first.
```