### PR TITLE
Update Debian repository domain in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,11 @@ at [unregistry-debian](https://github.com/dariogriffo/unregistry-debian/) by @da
 You can install unregistry the debian way by running:
 
 ```sh
-curl -sS https://debian.griffo.io/EA0F721D231FDD3A0A17B9AC7808B4DD62C41256.asc | sudo gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/debian.griffo.io.gpg
-echo "deb https://debian.griffo.io/apt $(lsb_release -sc 2>/dev/null) main" | sudo tee /etc/apt/sources.list.d/debian.griffo.io.list
-apt install -y unregistry
-apt install docker-pussh
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://deb.griffo.io/EA0F721D231FDD3A0A17B9AC7808B4DD62C41256.asc | sudo gpg --dearmor --yes -o /etc/apt/keyrings/deb.griffo.io.gpg
+echo "deb [signed-by=/etc/apt/keyrings/deb.griffo.io.gpg] https://deb.griffo.io/apt $(lsb_release -sc 2>/dev/null) main" | sudo tee /etc/apt/sources.list.d/deb.griffo.io.list
+sudo apt update
+sudo apt install -y unregistry docker-pussh
 ```
 
 or in the releases page of the repository [here](https://github.com/dariogriffo/unregistry-debian/releases)


### PR DESCRIPTION
Same change as psviderski/uncloud#413: the community Debian repository hosting unregistry and docker-pussh packages moved from `debian.griffo.io` to `deb.griffo.io` to comply with the [Debian trademark policy](https://www.debian.org/trademark) — same repository and signing key, old domain redirects permanently. The snippet also now uses the modern `/etc/apt/keyrings` + `signed-by=` layout and adds the missing `sudo`/`apt update` steps.